### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Intelligent cloud hosted site search with self-learning search technology to inc
 <hr />
 <h3>Compatible with:</h3>
 <ul>
-<li>Magento Open Source (CE) 2.1.18, 2.2.11, 2.3.7-p3, 2.4.4.</li>
-<li>Magento Commerce (EE) 2.1.18, 2.2.11, 2.3.7-p3, 2.4.4.</li>
+<li>Magento Open Source (CE) 2.1.18, 2.2.11, 2.3.7-p3</li>
+<li>Magento Commerce (EE) 2.1.18, 2.2.11, 2.3.7-p3</li>
 </ul>
 <em>Note, while this module will run on a number of earlier versions, official compatibility is only provided for the latest patch version (as above).</em>
 


### PR DESCRIPTION
Please update the "Compatible with:" section or upgrade the module, this module is not compatible with Magento 2.4.4

Dependancy module klevu/module-mysqlcompat: 1.1.0  has a class Klevu\MysqlCompat\Model\Search\TableMapper that relies on \Magento\CatalogSearch\Model\Search\TableMapper which does not exist anymore in Mage 2.4.4